### PR TITLE
Fix for URI escaping bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ blib/
 _build/
 Makefile
 pm_to_blib
+MYMETA.*

--- a/t/02_account.t
+++ b/t/02_account.t
@@ -18,7 +18,7 @@ if ( Params::Util::_STRING($ENV{'CAMPAIGN_MONITOR_API_KEY'}) ) {
   });
 }
 
-SKIP: {	
+SKIP: {
 	skip 'Invalid API Key supplied', 11 if $api_key eq '';
 
 	ok( $cm->account_clients()->{'code'} eq '200', 'Clients' );
@@ -28,28 +28,23 @@ SKIP: {
 	ok( $cm->account_systemdate()->{'code'} eq '200', 'System Date' );
 
 	my %new_admin = (
-		'EmailAddress'         	=> "jane.admin\@example.com",
+		'EmailAddress'         	=> "jane.admin+stuff\@example.com",
 		'Name'                 	=> "Jane Doe"
 	);
 
 	my %update_admin = (
-		'email'					=> "jane.admin\@example.com",
+		'email'                	=> "jane.admin+stuff\@example.com",
 		'EmailAddress'         	=> "jane.new\@example.com",
 		'Name'                 	=> "Jane Doeman"
 	);
 
-	my $admin_email = "jane.new\@example.com";	
+	my $admin_email = "jane.new\@example.com";
 
 	ok( $cm->account_addadmin(%new_admin)->{code} eq '201', 'Added new admin' );
 	ok( $cm->account_updateadmin(%update_admin)->{code} eq '200', 'Updated admin' );
-	ok( $cm->account_getadmins()->{code} eq '200', 'Got admins' );	
+	ok( $cm->account_getadmins()->{code} eq '200', 'Got admins' );
 	ok( $cm->account_getadmin($admin_email)->{code} eq '200', 'Got admin' );
 	ok( $cm->account_getprimarycontact()->{code} eq '200', 'Got admin primary contact' );
 	ok( $cm->account_deleteadmin($admin_email)->{code} eq '200', 'Delete admin' );
-	
+
 }
-
-
-
-
-

--- a/t/06_subscribers.t
+++ b/t/06_subscribers.t
@@ -42,7 +42,7 @@ SKIP: {
       }
     ],
     'Name'         => 'New Subscriber',
-    'EmailAddress' => 'subscriber@example.com',
+    'EmailAddress' => 'subscriber+stuff@example.com',
     'listid'       => $list_id,
   );
 
@@ -67,7 +67,7 @@ SKIP: {
     'Name'         => 'Renamed Subscriber',
     'EmailAddress' => 'subscriber@example.com',
     'listid'       => $list_id,
-    'email'        => 'subscriber@example.com'
+    'email'        => 'subscriber+stuff@example.com'
   );
 
   my %new_subscribers = (


### PR DESCRIPTION
Hi, I've run into a bug where several of our subscribers could be bulk imported but every attempt to operate on them individually gave bad request 400 errors. They all had plus '+' signs in their email addresses, when being operated on individually the email address provided to the API as a query parameter and URI::Escape was only being used for authentication, not for any other request. However the API naturally requires all such parameters to be URI escaped.

Rather than build requests by string concatenation and remembering to splice in calls to uri_escape in all the right places, I wrote private methods _build_request and _rest which accept data structures describing the request and build the request using the URI module.

Along the way I tidied up some of the method parameter handling to make it clearer from the source how parameters are to be supplied.

In order to test this I just added "+stuff" to email addresses in 02_account.t and 06_subscribers.t so that these objects are initially created with email addresses requiring URI escaping and are subsequently updated to not have the "+stuff". 

I hope the change is not too big, but it does fix a pretty significant bug in the module.
