### PR TITLE
Added support for getting an external session login URL.

### DIFF
--- a/lib/Net/CampaignMonitor.pm
+++ b/lib/Net/CampaignMonitor.pm
@@ -280,6 +280,14 @@ sub account_getprimarycontact {
   return $self->_build_results();
 }
 
+sub account_externalsession {
+  my ($self, %request) = @_;
+
+  $self->_rest(PUT => 'externalsession', undef, \%request);
+
+  return $self->_build_results();
+}
+
 sub client_clientid {
   my ($self, $client_id) = @_;
 
@@ -1479,6 +1487,18 @@ L<Sets the primary contact for the account to be the administrator with the spec
 L<Returns the email address of the administrator who is selected as the primary contact for this account.|http://www.campaignmonitor.com/api/account/#getting_primary_contact>
 
   my $primarycontact_email = $cm->account_getprimarycontact();
+
+=head2 account_externalsession
+
+L<Returns a URL which initiates a new external Campaign Monitor login session for the user with the given email.|http://www.campaignmonitor.com/api/account/#single_sign_on>
+
+  my $external_session = $cm->account_externalsession((
+    'Email'        => 'example@example.com',
+    'Chrome'       => 'None',
+    'Url'          => '/subscribers/search?search=belle@example.com',
+    'IntegratorID' => 'a1b2c3d4e5f6',
+    'ClientID'     => 'aaa111bbb222ccc333'
+  ));
 
 =head2 campaigns
 

--- a/t/02_account.t
+++ b/t/02_account.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 11;
+use Test::More tests => 12;
 use Params::Util qw{_STRING};
 use Net::CampaignMonitor;
 
@@ -19,7 +19,7 @@ if ( Params::Util::_STRING($ENV{'CAMPAIGN_MONITOR_API_KEY'}) ) {
 }
 
 SKIP: {
-	skip 'Invalid API Key supplied', 11 if $api_key eq '';
+	skip 'Invalid API Key supplied', 12 if $api_key eq '';
 
 	ok( $cm->account_clients()->{'code'} eq '200', 'Clients' );
 	ok( $cm->account_billingdetails()->{'code'} eq '200', 'Billing details' );
@@ -32,6 +32,14 @@ SKIP: {
 		'Name'                 	=> "Jane Doe"
 	);
 
+	my %session_options = (
+		'Email'        => "jane.admin+stuff\@example.com",
+    'Chrome'       => 'All',
+    'Url'          => '/subscribers',
+    'IntegratorID' => 'b92b429143b836fb',
+    'ClientID'     => ''
+	);
+
 	my %update_admin = (
 		'email'                	=> "jane.admin+stuff\@example.com",
 		'EmailAddress'         	=> "jane.new\@example.com",
@@ -41,6 +49,7 @@ SKIP: {
 	my $admin_email = "jane.new\@example.com";
 
 	ok( $cm->account_addadmin(%new_admin)->{code} eq '201', 'Added new admin' );
+  ok( $cm->account_externalsession(%session_options)->{code} eq '200', 'Got external session url' );
 	ok( $cm->account_updateadmin(%update_admin)->{code} eq '200', 'Updated admin' );
 	ok( $cm->account_getadmins()->{code} eq '200', 'Got admins' );
 	ok( $cm->account_getadmin($admin_email)->{code} eq '200', 'Got admin' );


### PR DESCRIPTION
Added support for the feature which allows an API caller to get a URL which initiates a login for an external Campaign Monitor session.

API docs: http://www.campaignmonitor.com/api/account/#single_sign_on
