### PR TITLE
Explicitly set SSL cert verify_hostname if using https API 

### DIFF
--- a/lib/Net/CampaignMonitor.pm
+++ b/lib/Net/CampaignMonitor.pm
@@ -106,6 +106,10 @@ sub create_rest_client {
 
   my $ua = LWP::UserAgent->new;
   $ua->agent($self->{useragent});
+  if ($self->{secure}) {
+   $ua->ssl_opts( verify_hostname => 1 );
+  }
+  
   if (exists $self->{access_token}) {
     $ua->default_header('Authorization' => 'Bearer '.$self->{access_token});
   } elsif (exists $self->{api_key}) {


### PR DESCRIPTION
verify_hostname is already set by default (it can be overwritten by an environment variable), so this is just an extra safeguard and not an urgent fix.
